### PR TITLE
>> Updated all diag_step functions. Removed all csm[0] and csm[1] add…

### DIFF
--- a/linmdtw/DTWGPU.cu
+++ b/linmdtw/DTWGPU.cu
@@ -62,27 +62,27 @@ __global__ void DTW_Diag_Step(float* d0, float* d1, float* d2, float* csm0, floa
                 diag = -1;
                 if (j1 == 0) {
                     if (idx > 0) {
-                        left = d1[idx-1] + csm1[idx-1];
+                        left = d1[idx-1];
                     }
                     if (idx > 0 && thisi > 0) {
-                        diag = d0[idx-1] + csm0[idx-1];
+                        diag = d0[idx-1];
                     }
                     if (thisi > 0) {
-                        up = d1[idx] + csm1[idx];
+                        up = d1[idx];
                     }
                 }
                 else if (i1 == M-1 && j1 == 1) {
-                    left = d1[idx] + csm1[idx];
+                    left = d1[idx];
                     if (thisi > 0) {
-                        diag = d0[idx] + csm0[idx];
-                        up = d1[idx+1] + csm1[idx+1];
+                        diag = d0[idx];
+                        up = d1[idx+1];
                     }
                 }
                 else if (i1 == M-1 && j1 > 1) {
-                    left = d1[idx] + csm1[idx];
+                    left = d1[idx];
                     if (thisi > 0) {
-                        diag = d0[idx+1] + csm0[idx+1];
-                        up = d1[idx+1] + csm1[idx+1];
+                        diag = d0[idx+1];
+                        up = d1[idx+1];
                     }
                 }
                 if (left > -1) {
@@ -102,6 +102,6 @@ __global__ void DTW_Diag_Step(float* d0, float* d1, float* d2, float* csm0, floa
                 }
             }
         }
-        d2[idx] = score;
+        d2[idx] = score + csm2[idx];
     }
 }

--- a/linmdtw/dtw.cpp
+++ b/linmdtw/dtw.cpp
@@ -123,7 +123,7 @@ void c_diag_step(float* d0, float* d1, float* d2, float* csm0, float* csm1, floa
                 csm2[idx] += diff*diff;
             }
             csm2[idx] = sqrt(csm2[idx]);
-            
+
 
             // Step 2: Figure out the optimal cost
             if (thisi == 0 && thisj == 0) {
@@ -141,27 +141,27 @@ void c_diag_step(float* d0, float* d1, float* d2, float* csm0, float* csm1, floa
                 diag = -1;
                 if (j1 == 0) {
                     if (idx > 0) {
-                        left = d1[idx-1] + csm1[idx-1];
+                        left = d1[idx-1];
                     }
                     if (idx > 0 && thisi > 0) {
-                        diag = d0[idx-1] + csm0[idx-1];
+                        diag = d0[idx-1];
                     }
                     if (thisi > 0) {
-                        up = d1[idx] + csm1[idx];
+                        up = d1[idx];
                     }
                 }
                 else if (i1 == M-1 && j1 == 1) {
-                    left = d1[idx] + csm1[idx];
+                    left = d1[idx];
                     if (thisi > 0) {
-                        diag = d0[idx] + csm0[idx];
-                        up = d1[idx+1] + csm1[idx+1];
+                        diag = d0[idx];
+                        up = d1[idx+1];
                     }
                 }
                 else if (i1 == M-1 && j1 > 1) {
-                    left = d1[idx] + csm1[idx];
+                    left = d1[idx];
                     if (thisi > 0) {
-                        diag = d0[idx+1] + csm0[idx+1];
-                        up = d1[idx+1] + csm1[idx+1];
+                        diag = d0[idx+1];
+                        up = d1[idx+1];
                     }
                 }
                 if (left > -1) {
@@ -181,6 +181,7 @@ void c_diag_step(float* d0, float* d1, float* d2, float* csm0, float* csm1, floa
                 }
             }
         }
-        d2[idx] = score;
+        d2[idx] = score + csm2[idx];    // optimal accumulated cost + euclidean cost
+
     }
 }

--- a/linmdtw/dtwgpu.py
+++ b/linmdtw/dtwgpu.py
@@ -63,7 +63,7 @@ def init_gpu():
 
                 // Step 2: Figure out the optimal cost
                 if (thisi == 0 && thisj == 0) {
-                    score = 0;
+                    score = 0 + csm2[idx];
                     if (debug == -1) {
                         S[0] = 0;
                         U[0] = -1;
@@ -77,27 +77,27 @@ def init_gpu():
                     diag = -1;
                     if (j1 == 0) {
                         if (idx > 0) {
-                            left = d1[idx-1] + csm1[idx-1];
+                            left = d1[idx-1];
                         }
                         if (idx > 0 && thisi > 0) {
-                            diag = d0[idx-1] + csm0[idx-1];
+                            diag = d0[idx-1];
                         }
                         if (thisi > 0) {
-                            up = d1[idx] + csm1[idx];
+                            up = d1[idx];
                         }
                     }
                     else if (i1 == M-1 && j1 == 1) {
-                        left = d1[idx] + csm1[idx];
+                        left = d1[idx];
                         if (thisi > 0) {
-                            diag = d0[idx] + csm0[idx];
-                            up = d1[idx+1] + csm1[idx+1];
+                            diag = d0[idx];
+                            up = d1[idx+1];
                         }
                     }
                     else if (i1 == M-1 && j1 > 1) {
-                        left = d1[idx] + csm1[idx];
+                        left = d1[idx];
                         if (thisi > 0) {
-                            diag = d0[idx+1] + csm0[idx+1];
-                            up = d1[idx+1] + csm1[idx+1];
+                            diag = d0[idx+1];
+                            up = d1[idx+1];
                         }
                     }
                     if (left > -1) {
@@ -117,7 +117,7 @@ def init_gpu():
                     }
                 }
             }
-            d2[idx] = score;
+            d2[idx] = score + csm2[idx];
         }
     }
     """


### PR DESCRIPTION
I removed all the additions to the directions (up, diag, left) and instead added to the score the cost of the field.

In dtw.py for the diag arrays I removed the -1 entry and the corresponding costmatrix entry. Then I added according to the formula presented in the paper. Additionally I added a parameter `shift` such that it shifts the index if a `-1` was removed in the first spot of a diagonal. 